### PR TITLE
Fixed Broken Links

### DIFF
--- a/codelabs/deploy-easytravel-at-localhost/index.html
+++ b/codelabs/deploy-easytravel-at-localhost/index.html
@@ -9,7 +9,7 @@
   <title>Deploying Easytravel @ 127.0.0.1</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.css">
   <style>
     .success {
       color: #1e8e3e;
@@ -232,10 +232,10 @@ installation done
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/prettify.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/codelabs/why-devs-love-dynatrace-1/index.html
+++ b/codelabs/why-devs-love-dynatrace-1/index.html
@@ -449,10 +449,10 @@ x-developer: yourname
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/prettify.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/codelabs/why-devs-love-dynatrace-1/index.html
+++ b/codelabs/why-devs-love-dynatrace-1/index.html
@@ -9,7 +9,7 @@
   <title>Why Devs Love Dynatrace - Episode 1</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.css">
   <style>
     .success {
       color: #1e8e3e;

--- a/codelabs/why-devs-love-dynatrace-2/index.html
+++ b/codelabs/why-devs-love-dynatrace-2/index.html
@@ -9,7 +9,7 @@
   <title>Why Devs Love Dynatrace - Episode 2</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.css">
   <style>
     .success {
       color: #1e8e3e;
@@ -300,10 +300,10 @@ Password: keptn
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/prettify.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/codelabs/why-devs-love-dynatrace-3/index.html
+++ b/codelabs/why-devs-love-dynatrace-3/index.html
@@ -9,7 +9,7 @@
   <title>Why Devs Love Dynatrace - Episode 3</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.css">
   <style>
     .success {
       color: #1e8e3e;
@@ -56,10 +56,10 @@
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/prettify.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.js"></script>
 
 </body>
 </html>

--- a/codelabs/why-devs-love-dynatrace-4/index.html
+++ b/codelabs/why-devs-love-dynatrace-4/index.html
@@ -9,7 +9,7 @@
   <title>Why Devs Love Dynatrace - Episode 4</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements/codelab-elements.css">
+  <link rel="stylesheet" href="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.css">
   <style>
     .success {
       color: #1e8e3e;
@@ -42,10 +42,10 @@
     
   </google-codelab>
 
-  <script src="https://storage.googleapis.com/codelab-elements/native-shim.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/custom-elements.min.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
-  <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/prettify.js"></script>
+  <script src="https://storage.googleapis.com/codelab-elements-tmp/codelab-elements.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Codelabs were broken because linked css and js files are getting access denied on
[https://storage.googleapis.com/codelab-elements](https://nam02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fstorage.googleapis.com%2Fcodelab-elements&data=05%7C01%7Cdaniel.braaf%40dynatrace.com%7C03cd8265b08642337b5208dae7e13228%7C70ebe3a35b30435d9d677716d74ca190%7C1%7C0%7C638077251634600574%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=enXN5NQRggZHpgu4qWp2H%2FceQbrcrMdw%2F1YVNnvDwHk%3D&reserved=0)

Workaround is to use:
[https://storage.googleapis.com/codelab-elements-tmp](https://nam02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fstorage.googleapis.com%2Fcodelab-elements-tmp&data=05%7C01%7Cdaniel.braaf%40dynatrace.com%7C03cd8265b08642337b5208dae7e13228%7C70ebe3a35b30435d9d677716d74ca190%7C1%7C0%7C638077251634600574%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=vHn3PxxC2bP9OkrR0VnuWwNxQyRaE5V7ojD7dyYwuRI%3D&reserved=0)

Found this problem in issue 801 of codelabs repo
[https://github.com/googlecodelabs/tools/issues/801](https://nam02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fgooglecodelabs%2Ftools%2Fissues%2F801&data=05%7C01%7Cdaniel.braaf%40dynatrace.com%7C03cd8265b08642337b5208dae7e13228%7C70ebe3a35b30435d9d677716d74ca190%7C1%7C0%7C638077251634600574%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=WEfnO8T%2F3CREjMbzR2c8hQccBH%2FgmTcTWNq%2BNGEwmrA%3D&reserved=0)
